### PR TITLE
英辞郎のデータコンバート時にLevel.definitionが設定されるよう修正

### DIFF
--- a/lib/eijiro.rb
+++ b/lib/eijiro.rb
@@ -61,24 +61,6 @@ class EijiroDictionary
     db.close
   end
 
-  def import_acl_12000
-    puts "Import ALC12000 words..."
-    db = SQLite3::Database.new(@dbfile)
-    (1..12).each do |level|
-      pbar = ProgressBar.new("Level #{level}", Level.where(level: level).count)
-      Level.where(level: level).map(&:word).each do |word|
-        word.downcase!
-        pbar.inc
-        eijiro = db.execute("SELECT items.body FROM items WHERE entry = #{sqlstr(word)}")
-        reijiro = db.execute("SELECT items.body FROM items INNER JOIN inverts ON items.id = inverts.item_id WHERE inverts.token = #{sqlstr(word)} AND items.entry != #{sqlstr(word)}")
-        definition = (eijiro + reijiro).join("\n")
-        db.execute("INSERT INTO words (entry, level, definition) VALUES (#{sqlstr(word)}, #{level}, #{sqlstr(definition)});")
-      end
-      pbar.finish
-    end
-    db.close
-  end
-
 private
 
   def find_dictionaries(path)

--- a/lib/eijiro.rb
+++ b/lib/eijiro.rb
@@ -54,7 +54,8 @@ class EijiroDictionary
     db = SQLite3::Database.new(@dbfile)
     (1..12).each do |level|
       @level_table[level].each do |word|
-        db.execute("INSERT INTO levels (word, level) VALUES (#{sqlstr(word)}, #{level});")
+        definition = db.execute("SELECT items.body FROM items WHERE entry = #{sqlstr(word)}").first.first
+        db.execute("INSERT INTO levels (word, level, definition) VALUES (#{sqlstr(word)}, #{level}, #{sqlstr(definition)});")
       end
     end
     db.close


### PR DESCRIPTION
https://github.com/knsmr/reijiro/issues/4
に対する修正です。

